### PR TITLE
Config not show dialog when upload

### DIFF
--- a/flameshot.example.ini
+++ b/flameshot.example.ini
@@ -87,6 +87,9 @@
 ;; Upload to imgur without confirmation (bool)
 ;uploadWithoutConfirmation=false
 ;
+;; Upload to imgur without confirmation (bool)
+;showDialogAfterUpload=false
+;
 ;; Use larger color palette as the default one
 ; predefinedColorPaletteLarge=false
 ;

--- a/src/config/generalconf.cpp
+++ b/src/config/generalconf.cpp
@@ -52,6 +52,7 @@ GeneralConf::GeneralConf(QWidget* parent)
     initCopyPathAfterSave();
     initCopyAndCloseAfterUpload();
     initUploadWithoutConfirmation();
+    initShowDialogAfterUpload();
     initHistoryConfirmationToDelete();
     initAntialiasingPinZoom();
     initUploadHistoryMax();
@@ -84,6 +85,7 @@ void GeneralConf::_updateComponents(bool allowEmptySavePath)
     m_useJpgForClipboard->setChecked(config.useJpgForClipboard());
     m_copyOnDoubleClick->setChecked(config.copyOnDoubleClick());
     m_uploadWithoutConfirmation->setChecked(config.uploadWithoutConfirmation());
+    m_showDialogAfterUpload->setChecked(config.showDialogAfterUpload());
     m_historyConfirmationToDelete->setChecked(
       config.historyConfirmationToDelete());
 #if !defined(DISABLE_UPDATE_CHECKER)
@@ -672,6 +674,17 @@ void GeneralConf::initUploadWithoutConfirmation()
     m_scrollAreaLayout->addWidget(m_uploadWithoutConfirmation);
     connect(m_uploadWithoutConfirmation, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setUploadWithoutConfirmation(checked);
+    });
+}
+
+void GeneralConf::initShowDialogAfterUpload()
+{
+    m_showDialogAfterUpload =
+      new QCheckBox(tr("Show dialog after upload"), this);
+    m_showDialogAfterUpload->setToolTip(tr("Show dialog after upload"));
+    m_scrollAreaLayout->addWidget(m_showDialogAfterUpload);
+    connect(m_showDialogAfterUpload, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setShowDialogAfterUpload(checked);
     });
 }
 

--- a/src/config/generalconf.h
+++ b/src/config/generalconf.h
@@ -86,6 +86,7 @@ private:
     void initSquareMagnifier();
     void initUndoLimit();
     void initUploadWithoutConfirmation();
+    void initShowDialogAfterUpload();
     void initUseJpgForClipboard();
     void initUploadHistoryMax();
     void initUploadClientSecret();
@@ -115,6 +116,7 @@ private:
     QCheckBox* m_antialiasingPinZoom;
     QCheckBox* m_saveLastRegion;
     QCheckBox* m_uploadWithoutConfirmation;
+    QCheckBox* m_showDialogAfterUpload;
     QPushButton* m_importButton;
     QPushButton* m_exportButton;
     QPushButton* m_resetButton;

--- a/src/core/flameshot.cpp
+++ b/src/core/flameshot.cpp
@@ -411,7 +411,11 @@ void Flameshot::exportCapture(const QPixmap& capture,
                       FlameshotDaemon::copyToClipboard(
                         url.toString(), tr("URL copied to clipboard."));
                   }
-                  widget->showPostUploadDialog();
+                  if (ConfigHandler().showDialogAfterUpload()) {
+                      widget->showPostUploadDialog();
+                  } else {
+                      widget->deleteLater();
+                  }
               }
           });
     }

--- a/src/tools/capturetool.h
+++ b/src/tools/capturetool.h
@@ -85,7 +85,7 @@ public:
     {}
 
     // TODO unused
-    virtual void setCapture(const QPixmap& pixmap){};
+    virtual void setCapture(const QPixmap& pixmap) {};
 
     // Returns false when the tool is in an inconsistent state and shouldn't
     // be included in the tool undo/redo stack.

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -55,15 +55,12 @@ bool verifyLaunchFile()
  *             misbehave.
  */
 #define OPTION(KEY, TYPE)                                                      \
-    {                                                                          \
-        QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE)            \
-    }
+    { QStringLiteral(KEY), QSharedPointer<ValueHandler>(new TYPE) }
 
 #define SHORTCUT(NAME, DEFAULT_VALUE)                                          \
-    {                                                                          \
-        QStringLiteral(NAME), QSharedPointer<KeySequence>(new KeySequence(     \
-                                QKeySequence(QLatin1String(DEFAULT_VALUE))))   \
-    }
+    { QStringLiteral(NAME),                                                    \
+      QSharedPointer<KeySequence>(                                             \
+        new KeySequence(QKeySequence(QLatin1String(DEFAULT_VALUE)))) }
 
 /**
  * This map contains all the information that is needed to parse, verify and
@@ -96,6 +93,7 @@ static QMap<class QString, QSharedPointer<ValueHandler>>
     OPTION("antialiasingPinZoom"         ,Bool               ( true          )),
     OPTION("useJpgForClipboard"          ,Bool               ( false         )),
     OPTION("uploadWithoutConfirmation"   ,Bool               ( false         )),
+    OPTION("showDialogAfterUpload"       ,Bool               ( false         )),
     OPTION("saveAfterCopy"               ,Bool               ( false         )),
     OPTION("savePath"                    ,ExistingDir        (                   )),
     OPTION("savePathFixed"               ,Bool               ( false         )),
@@ -198,7 +196,7 @@ ConfigHandler::ConfigHandler()
         QObject::connect(m_configWatcher.data(),
                          &QFileSystemWatcher::fileChanged,
                          [](const QString& fileName) {
-                             emit getInstance()->fileChanged();
+                             emit getInstance() -> fileChanged();
 
                              if (QFile(fileName).exists()) {
                                  m_configWatcher->addPath(fileName);
@@ -693,12 +691,12 @@ void ConfigHandler::setErrorState(bool error) const
     if (!hadError && m_hasError) {
         QString msg = errorMessage();
         AbstractLogger::error() << msg;
-        emit getInstance()->error();
+        emit getInstance() -> error();
     } else if (hadError && !m_hasError) {
         auto msg =
           tr("You have successfully resolved the configuration error.");
         AbstractLogger::info() << msg;
-        emit getInstance()->errorResolved();
+        emit getInstance() -> errorResolved();
     }
 }
 

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -116,6 +116,7 @@ public:
     CONFIG_GETTER_SETTER(uploadWithoutConfirmation,
                          setUploadWithoutConfirmation,
                          bool)
+    CONFIG_GETTER_SETTER(showDialogAfterUpload, setShowDialogAfterUpload, bool)
     CONFIG_GETTER_SETTER(ignoreUpdateToVersion,
                          setIgnoreUpdateToVersion,
                          QString)

--- a/src/widgets/capture/capturetoolbutton.cpp
+++ b/src/widgets/capture/capturetoolbutton.cpp
@@ -135,28 +135,37 @@ void CaptureToolButton::setColor(const QColor& c)
 
 QColor CaptureToolButton::m_mainColor;
 
-static std::map<CaptureTool::Type, int> buttonTypeOrder
-{
-    { CaptureTool::TYPE_PENCIL, 0 }, { CaptureTool::TYPE_DRAWER, 1 },
-      { CaptureTool::TYPE_ARROW, 2 }, { CaptureTool::TYPE_SELECTION, 3 },
-      { CaptureTool::TYPE_RECTANGLE, 4 }, { CaptureTool::TYPE_CIRCLE, 5 },
-      { CaptureTool::TYPE_MARKER, 6 }, { CaptureTool::TYPE_TEXT, 7 },
-      { CaptureTool::TYPE_PIXELATE, 8 }, { CaptureTool::TYPE_INVERT, 9 },
-      { CaptureTool::TYPE_CIRCLECOUNT, 10 },
-      { CaptureTool::TYPE_SELECTIONINDICATOR, 11 },
-      { CaptureTool::TYPE_MOVESELECTION, 12 }, { CaptureTool::TYPE_UNDO, 13 },
-      { CaptureTool::TYPE_REDO, 14 }, { CaptureTool::TYPE_COPY, 15 },
-      { CaptureTool::TYPE_SAVE, 16 }, { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
-      { CaptureTool::TYPE_ACCEPT, 18 },
+static std::map<CaptureTool::Type, int> buttonTypeOrder{
+    { CaptureTool::TYPE_PENCIL, 0 },
+    { CaptureTool::TYPE_DRAWER, 1 },
+    { CaptureTool::TYPE_ARROW, 2 },
+    { CaptureTool::TYPE_SELECTION, 3 },
+    { CaptureTool::TYPE_RECTANGLE, 4 },
+    { CaptureTool::TYPE_CIRCLE, 5 },
+    { CaptureTool::TYPE_MARKER, 6 },
+    { CaptureTool::TYPE_TEXT, 7 },
+    { CaptureTool::TYPE_PIXELATE, 8 },
+    { CaptureTool::TYPE_INVERT, 9 },
+    { CaptureTool::TYPE_CIRCLECOUNT, 10 },
+    { CaptureTool::TYPE_SELECTIONINDICATOR, 11 },
+    { CaptureTool::TYPE_MOVESELECTION, 12 },
+    { CaptureTool::TYPE_UNDO, 13 },
+    { CaptureTool::TYPE_REDO, 14 },
+    { CaptureTool::TYPE_COPY, 15 },
+    { CaptureTool::TYPE_SAVE, 16 },
+    { CaptureTool::TYPE_IMAGEUPLOADER, 17 },
+    { CaptureTool::TYPE_ACCEPT, 18 },
 #if !defined(Q_OS_MACOS)
-      { CaptureTool::TYPE_OPEN_APP, 19 }, { CaptureTool::TYPE_EXIT, 20 },
-      { CaptureTool::TYPE_PIN, 21 },
+    { CaptureTool::TYPE_OPEN_APP, 19 },
+    { CaptureTool::TYPE_EXIT, 20 },
+    { CaptureTool::TYPE_PIN, 21 },
 #else
-      { CaptureTool::TYPE_EXIT, 19 }, { CaptureTool::TYPE_PIN, 20 },
+    { CaptureTool::TYPE_EXIT, 19 },
+    { CaptureTool::TYPE_PIN, 20 },
 #endif
 
-      { CaptureTool::TYPE_SIZEINCREASE, 22 },
-      { CaptureTool::TYPE_SIZEDECREASE, 23 },
+    { CaptureTool::TYPE_SIZEINCREASE, 22 },
+    { CaptureTool::TYPE_SIZEDECREASE, 23 },
 };
 
 int CaptureToolButton::getPriorityByButton(CaptureTool::Type b)

--- a/src/widgets/capture/capturewidget.cpp
+++ b/src/widgets/capture/capturewidget.cpp
@@ -280,7 +280,7 @@ CaptureWidget::~CaptureWidget()
         Flameshot::instance()->exportCapture(
           pixmap(), geometry, m_context.request);
     } else {
-        emit Flameshot::instance()->captureFailed();
+        emit Flameshot::instance() -> captureFailed();
     }
 }
 


### PR DESCRIPTION
Config not show dialog when upload

When choose upload image after screenshot, it will have a dialog to confirm user want to upload. Add config to support case user only want to get the URL after upload when click upload not to re-confirm.
